### PR TITLE
Add Cloudflare Workers deploy to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Tests
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -19,3 +21,23 @@ jobs:
       - run: npm ci
 
       - run: npm test
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run deploy
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `push` trigger on `main` so the workflow runs after merges (not just on PRs)
- Add a `deploy` job that runs `npm run deploy` (wrangler deploy) after tests pass
- Deploy only triggers on push to main, using `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` secrets

## Test plan
- [ ] PR triggers the test job (existing behavior)
- [ ] After merging, tests run on main, then the deploy job triggers
- [ ] Confirm the worker deploys at the Cloudflare Workers URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)