### PR TITLE
Add smoke tests after deploy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,30 @@ jobs:
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Smoke test - health check
+        run: |
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' 'https://linkedin-currency-converter.tvs-consult.workers.dev/convert?amount=1&from=USD&to=EUR')
+          if [ "$STATUS" != "200" ]; then
+            echo "Health check failed with status $STATUS"
+            exit 1
+          fi
+
+      - name: Smoke test - response validation
+        run: |
+          RESPONSE=$(curl -s 'https://linkedin-currency-converter.tvs-consult.workers.dev/convert?amount=100&from=USD&to=EUR')
+          echo "$RESPONSE"
+          echo "$RESPONSE" | jq -e '.from == "USD"' > /dev/null
+          echo "$RESPONSE" | jq -e '.to == "EUR"' > /dev/null
+          echo "$RESPONSE" | jq -e '.amount == 100' > /dev/null
+          echo "$RESPONSE" | jq -e '.convertedAmount > 0' > /dev/null
+          echo "$RESPONSE" | jq -e '.rate > 0' > /dev/null
+          echo "$RESPONSE" | jq -e '.description' > /dev/null
+
+      - name: Smoke test - error handling
+        run: |
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' 'https://linkedin-currency-converter.tvs-consult.workers.dev/convert')
+          if [ "$STATUS" != "400" ]; then
+            echo "Expected 400 for missing params, got $STATUS"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds three post-deploy smoke tests to the `deploy` job in the CI workflow
- **Health check**: verifies a valid conversion request returns HTTP 200
- **Response validation**: verifies the JSON response contains all expected fields (`from`, `to`, `amount`, `convertedAmount`, `rate`, `description`) with valid values
- **Error handling**: verifies missing query params returns HTTP 400

## Test plan
- [ ] PR triggers the `test` job (existing unit tests) — no deploy
- [ ] After merging to `main`, the `deploy` job runs and deploys to Cloudflare Workers
- [ ] Smoke tests run against `https://linkedin-currency-converter.tvs-consult.workers.dev` and confirm the worker is live and responding correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)