### PR TITLE
Fix flaky e2e tests by adding exact matching to 'De' label selectors

### DIFF
--- a/packages/web/src/e2e/converter.spec.ts
+++ b/packages/web/src/e2e/converter.spec.ts
@@ -39,7 +39,7 @@ test('full conversion flow — enters amount, clicks Convertir, shows result', a
   await page.goto('/');
 
   // Wait for currencies to load (De defaults to USD)
-  await expect(page.getByLabel('De')).toHaveValue('USD');
+  await expect(page.getByLabel('De', { exact: true })).toHaveValue('USD');
   await expect(page.getByLabel('A', { exact: true })).toHaveValue('EUR');
 
   await page.getByLabel('Cantidad').fill('100');
@@ -52,14 +52,14 @@ test('full conversion flow — enters amount, clicks Convertir, shows result', a
 
 test('Convertir button is disabled when no amount is entered', async ({ page }) => {
   await page.goto('/');
-  await expect(page.getByLabel('De')).toHaveValue('USD');
+  await expect(page.getByLabel('De', { exact: true })).toHaveValue('USD');
 
   await expect(page.getByRole('button', { name: 'Convertir' })).toBeDisabled();
 });
 
 test('Convertir button is disabled when De equals A', async ({ page }) => {
   await page.goto('/');
-  await expect(page.getByLabel('De')).toHaveValue('USD');
+  await expect(page.getByLabel('De', { exact: true })).toHaveValue('USD');
 
   await page.getByLabel('Cantidad').fill('100');
   await page.getByLabel('A', { exact: true }).selectOption('USD');
@@ -79,7 +79,7 @@ test('shows API error message when conversion fails', async ({ page }) => {
   );
 
   await page.goto('/');
-  await expect(page.getByLabel('De')).toHaveValue('USD');
+  await expect(page.getByLabel('De', { exact: true })).toHaveValue('USD');
 
   await page.getByLabel('Cantidad').fill('100');
   await page.getByRole('button', { name: 'Convertir' }).click();


### PR DESCRIPTION
## Summary
Updated e2e test selectors to use exact label matching for the 'De' (from currency) field to prevent false positives when selecting form elements.

## Key Changes
- Added `{ exact: true }` option to all `page.getByLabel('De')` selectors across 4 test cases
- This ensures the selector matches only the 'De' label exactly, not partial matches that could include other labels containing 'De'

## Details
The `exact: true` option makes the label matching more precise and prevents the selector from accidentally matching other form labels that might contain the substring 'De'. This improves test reliability and consistency, as the 'A' (to currency) field was already using exact matching in the same tests.

Affected tests:
- full conversion flow test
- Convertir button disabled when no amount entered test
- Convertir button disabled when De equals A test
- API error message display test

https://claude.ai/code/session_01NFyZp72V9k8VmTRRZGt9Yb