### PR TITLE
feat: translate UI labels from Spanish back to English

### DIFF
--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from 'next';
 import './globals.css';
 
 export const metadata: Metadata = {
-  title: 'Conversor de Divisas',
-  description: 'Convierte entre USD y divisas del mundo',
+  title: 'Currency Converter',
+  description: 'Convert between USD and world currencies',
 };
 
 export default function RootLayout({
@@ -12,7 +12,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="es">
+    <html lang="en">
       <body>{children}</body>
     </html>
   );

--- a/packages/web/src/components/CurrencyConverter.test.tsx
+++ b/packages/web/src/components/CurrencyConverter.test.tsx
@@ -28,7 +28,7 @@ const MOCK_RESULT: ConversionResult = {
 /** Wait until both From/To selects are populated (currencies loaded). */
 async function waitForCurrencies() {
   await waitFor(() => {
-    expect(screen.getByLabelText('De')).toHaveValue('USD');
+    expect(screen.getByLabelText('From')).toHaveValue('USD');
   });
 }
 
@@ -38,14 +38,14 @@ describe('CurrencyConverter', () => {
     mockFetchCurrencies.mockResolvedValue({ currencies: CURRENCIES });
   });
 
-  it('renders amount input, from/to dropdowns and Convertir button', async () => {
+  it('renders amount input, from/to dropdowns and Convert button', async () => {
     render(<CurrencyConverter />);
     await waitForCurrencies();
 
-    expect(screen.getByLabelText('Cantidad')).toBeInTheDocument();
-    expect(screen.getByLabelText('De')).toBeInTheDocument();
-    expect(screen.getByLabelText('A')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Convertir' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Amount')).toBeInTheDocument();
+    expect(screen.getByLabelText('From')).toBeInTheDocument();
+    expect(screen.getByLabelText('To')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Convert' })).toBeInTheDocument();
   });
 
   it('fetches currencies on mount and populates dropdowns', async () => {
@@ -58,34 +58,34 @@ describe('CurrencyConverter', () => {
     expect(screen.getAllByRole('option', { name: 'USD' })).toHaveLength(2);
   });
 
-  it('Convertir button is disabled when amount is empty', async () => {
+  it('Convert button is disabled when amount is empty', async () => {
     render(<CurrencyConverter />);
     await waitForCurrencies();
 
-    expect(screen.getByRole('button', { name: 'Convertir' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Convert' })).toBeDisabled();
   });
 
-  it('Convertir button is disabled when amount is zero', async () => {
+  it('Convert button is disabled when amount is zero', async () => {
     const user = userEvent.setup();
     render(<CurrencyConverter />);
     await waitForCurrencies();
 
-    await user.type(screen.getByLabelText('Cantidad'), '0');
+    await user.type(screen.getByLabelText('Amount'), '0');
 
-    expect(screen.getByRole('button', { name: 'Convertir' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Convert' })).toBeDisabled();
   });
 
-  it('Convertir button is disabled when from equals to, and shows validation message', async () => {
+  it('Convert button is disabled when from equals to, and shows validation message', async () => {
     const user = userEvent.setup();
     render(<CurrencyConverter />);
     await waitForCurrencies();
 
-    await user.type(screen.getByLabelText('Cantidad'), '100');
-    await user.selectOptions(screen.getByLabelText('A'), 'USD');
+    await user.type(screen.getByLabelText('Amount'), '100');
+    await user.selectOptions(screen.getByLabelText('To'), 'USD');
 
-    expect(screen.getByRole('button', { name: 'Convertir' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Convert' })).toBeDisabled();
     expect(
-      screen.getByText('Las divisas de origen y destino deben ser diferentes.'),
+      screen.getByText('Source and target currencies must differ.'),
     ).toBeInTheDocument();
   });
 
@@ -99,20 +99,20 @@ describe('CurrencyConverter', () => {
     render(<CurrencyConverter />);
     await waitForCurrencies();
 
-    await user.type(screen.getByLabelText('Cantidad'), '100');
-    await user.click(screen.getByRole('button', { name: 'Convertir' }));
+    await user.type(screen.getByLabelText('Amount'), '100');
+    await user.click(screen.getByRole('button', { name: 'Convert' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Convirtiendo…' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Converting…' })).toBeDisabled();
     });
-    expect(screen.getByLabelText('Cantidad')).toBeDisabled();
-    expect(screen.getByLabelText('De')).toBeDisabled();
-    expect(screen.getByLabelText('A')).toBeDisabled();
+    expect(screen.getByLabelText('Amount')).toBeDisabled();
+    expect(screen.getByLabelText('From')).toBeDisabled();
+    expect(screen.getByLabelText('To')).toBeDisabled();
 
     // Resolve to clean up pending promise
     resolveFn(MOCK_RESULT);
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Convertir' })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Convert' })).not.toBeDisabled();
     });
   });
 
@@ -123,8 +123,8 @@ describe('CurrencyConverter', () => {
     render(<CurrencyConverter />);
     await waitForCurrencies();
 
-    await user.type(screen.getByLabelText('Cantidad'), '100');
-    await user.click(screen.getByRole('button', { name: 'Convertir' }));
+    await user.type(screen.getByLabelText('Amount'), '100');
+    await user.click(screen.getByRole('button', { name: 'Convert' }));
 
     await waitFor(() => {
       expect(screen.getByText(/92\.50/)).toBeInTheDocument();
@@ -140,8 +140,8 @@ describe('CurrencyConverter', () => {
     render(<CurrencyConverter />);
     await waitForCurrencies();
 
-    await user.type(screen.getByLabelText('Cantidad'), '100');
-    await user.click(screen.getByRole('button', { name: 'Convertir' }));
+    await user.type(screen.getByLabelText('Amount'), '100');
+    await user.click(screen.getByRole('button', { name: 'Convert' }));
 
     await waitFor(() => {
       expect(screen.getByText('Only USD conversions supported')).toBeInTheDocument();
@@ -156,35 +156,35 @@ describe('CurrencyConverter', () => {
     await waitForCurrencies();
 
     // First conversion
-    await user.type(screen.getByLabelText('Cantidad'), '100');
-    await user.click(screen.getByRole('button', { name: 'Convertir' }));
+    await user.type(screen.getByLabelText('Amount'), '100');
+    await user.click(screen.getByRole('button', { name: 'Convert' }));
     await waitFor(() => expect(screen.getByText(/92\.50/)).toBeInTheDocument());
 
     // Second conversion — previous result should be replaced
     const newResult = { ...MOCK_RESULT, convertedAmount: 185, to: 'GBP' };
     mockConvertCurrency.mockResolvedValue(newResult);
 
-    await user.clear(screen.getByLabelText('Cantidad'));
-    await user.type(screen.getByLabelText('Cantidad'), '200');
-    await user.selectOptions(screen.getByLabelText('A'), 'GBP');
-    await user.click(screen.getByRole('button', { name: 'Convertir' }));
+    await user.clear(screen.getByLabelText('Amount'));
+    await user.type(screen.getByLabelText('Amount'), '200');
+    await user.selectOptions(screen.getByLabelText('To'), 'GBP');
+    await user.click(screen.getByRole('button', { name: 'Convert' }));
 
     await waitFor(() => expect(screen.getByText(/185\.00/)).toBeInTheDocument());
     expect(screen.queryByText(/92\.50/)).not.toBeInTheDocument();
   });
 
-  it('shows currencies fetch error with a Reintentar button', async () => {
+  it('shows currencies fetch error with a Retry button', async () => {
     mockFetchCurrencies.mockRejectedValue(new Error('No se pudo conectar'));
 
     render(<CurrencyConverter />);
 
     await waitFor(() => {
-      expect(screen.getByText('Error al cargar las divisas.')).toBeInTheDocument();
+      expect(screen.getByText('Error loading currencies.')).toBeInTheDocument();
     });
-    expect(screen.getByRole('button', { name: 'Reintentar' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   });
 
-  it('Reintentar button re-fetches currencies and clears the error', async () => {
+  it('Retry button re-fetches currencies and clears the error', async () => {
     const user = userEvent.setup();
     mockFetchCurrencies
       .mockRejectedValueOnce(new Error('No se pudo conectar'))
@@ -192,13 +192,13 @@ describe('CurrencyConverter', () => {
 
     render(<CurrencyConverter />);
     await waitFor(() =>
-      expect(screen.getByText('Error al cargar las divisas.')).toBeInTheDocument(),
+      expect(screen.getByText('Error loading currencies.')).toBeInTheDocument(),
     );
 
-    await user.click(screen.getByRole('button', { name: 'Reintentar' }));
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
 
     await waitFor(() => {
-      expect(screen.queryByText('Error al cargar las divisas.')).not.toBeInTheDocument();
+      expect(screen.queryByText('Error loading currencies.')).not.toBeInTheDocument();
     });
     expect(screen.getAllByRole('option', { name: 'EUR' })).toHaveLength(2);
   });

--- a/packages/web/src/components/CurrencyConverter.tsx
+++ b/packages/web/src/components/CurrencyConverter.tsx
@@ -56,19 +56,19 @@ export default function CurrencyConverter() {
 
   return (
     <div className="w-full max-w-md bg-white rounded-2xl shadow-lg p-6 md:p-8">
-      <h1 className="text-2xl font-bold text-gray-900 mb-1">Conversor de Divisas</h1>
+      <h1 className="text-2xl font-bold text-gray-900 mb-1">Currency Converter</h1>
       <p className="text-sm text-gray-500 mb-6">
-        Convierte entre USD y más de 150 divisas del mundo
+        Convert between USD and 150+ world currencies
       </p>
 
       {currenciesError && (
         <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg flex items-center justify-between">
-          <span className="text-sm text-red-700">Error al cargar las divisas.</span>
+          <span className="text-sm text-red-700">Error loading currencies.</span>
           <button
             onClick={loadCurrencies}
             className="text-sm font-medium text-red-700 underline ml-3 hover:text-red-900"
           >
-            Reintentar
+            Retry
           </button>
         </div>
       )}
@@ -76,7 +76,7 @@ export default function CurrencyConverter() {
       <div className="space-y-4">
         <div>
           <label htmlFor="amount" className="block text-sm font-medium text-gray-700 mb-1">
-            Cantidad
+            Amount
           </label>
           <input
             id="amount"
@@ -94,7 +94,7 @@ export default function CurrencyConverter() {
         <div className="grid grid-cols-2 gap-3">
           <div>
             <label htmlFor="from" className="block text-sm font-medium text-gray-700 mb-1">
-              De
+              From
             </label>
             <select
               id="from"
@@ -103,7 +103,7 @@ export default function CurrencyConverter() {
               disabled={loading || currencies.length === 0}
               className="w-full px-3 py-2.5 border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-50 disabled:text-gray-500"
             >
-              <option value="">Seleccionar...</option>
+              <option value="">Select...</option>
               {currencies.map((c) => (
                 <option key={c} value={c}>
                   {c}
@@ -114,7 +114,7 @@ export default function CurrencyConverter() {
 
           <div>
             <label htmlFor="to" className="block text-sm font-medium text-gray-700 mb-1">
-              A
+              To
             </label>
             <select
               id="to"
@@ -123,7 +123,7 @@ export default function CurrencyConverter() {
               disabled={loading || currencies.length === 0}
               className="w-full px-3 py-2.5 border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-50 disabled:text-gray-500"
             >
-              <option value="">Seleccionar...</option>
+              <option value="">Select...</option>
               {currencies.map((c) => (
                 <option key={c} value={c}>
                   {c}
@@ -134,7 +134,7 @@ export default function CurrencyConverter() {
         </div>
 
         {from !== '' && to !== '' && from === to && (
-          <p className="text-sm text-red-600">Las divisas de origen y destino deben ser diferentes.</p>
+          <p className="text-sm text-red-600">Source and target currencies must differ.</p>
         )}
 
         <button
@@ -142,7 +142,7 @@ export default function CurrencyConverter() {
           disabled={!isValid || loading}
           className="w-full py-2.5 px-4 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
         >
-          {loading ? 'Convirtiendo…' : 'Convertir'}
+          {loading ? 'Converting…' : 'Convert'}
         </button>
       </div>
 

--- a/packages/web/src/e2e/converter.spec.ts
+++ b/packages/web/src/e2e/converter.spec.ts
@@ -35,37 +35,37 @@ test.beforeEach(async ({ page }) => {
   );
 });
 
-test('full conversion flow — enters amount, clicks Convertir, shows result', async ({ page }) => {
+test('full conversion flow — enters amount, clicks Convert, shows result', async ({ page }) => {
   await page.goto('/');
 
-  // Wait for currencies to load (De defaults to USD)
-  await expect(page.getByLabel('De', { exact: true })).toHaveValue('USD');
-  await expect(page.getByLabel('A', { exact: true })).toHaveValue('EUR');
+  // Wait for currencies to load (From defaults to USD)
+  await expect(page.getByLabel('From', { exact: true })).toHaveValue('USD');
+  await expect(page.getByLabel('To', { exact: true })).toHaveValue('EUR');
 
-  await page.getByLabel('Cantidad').fill('100');
-  await page.getByRole('button', { name: 'Convertir' }).click();
+  await page.getByLabel('Amount').fill('100');
+  await page.getByRole('button', { name: 'Convert' }).click();
 
   await expect(page.getByText(/92\.50/)).toBeVisible();
   await expect(page.getByText('1 USD = 0.925 EUR')).toBeVisible();
   await expect(page.getByText('Euro')).toBeVisible();
 });
 
-test('Convertir button is disabled when no amount is entered', async ({ page }) => {
+test('Convert button is disabled when no amount is entered', async ({ page }) => {
   await page.goto('/');
-  await expect(page.getByLabel('De', { exact: true })).toHaveValue('USD');
+  await expect(page.getByLabel('From', { exact: true })).toHaveValue('USD');
 
-  await expect(page.getByRole('button', { name: 'Convertir' })).toBeDisabled();
+  await expect(page.getByRole('button', { name: 'Convert' })).toBeDisabled();
 });
 
-test('Convertir button is disabled when De equals A', async ({ page }) => {
+test('Convert button is disabled when From equals To', async ({ page }) => {
   await page.goto('/');
-  await expect(page.getByLabel('De', { exact: true })).toHaveValue('USD');
+  await expect(page.getByLabel('From', { exact: true })).toHaveValue('USD');
 
-  await page.getByLabel('Cantidad').fill('100');
-  await page.getByLabel('A', { exact: true }).selectOption('USD');
+  await page.getByLabel('Amount').fill('100');
+  await page.getByLabel('To', { exact: true }).selectOption('USD');
 
-  await expect(page.getByRole('button', { name: 'Convertir' })).toBeDisabled();
-  await expect(page.getByText('Las divisas de origen y destino deben ser diferentes.')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Convert' })).toBeDisabled();
+  await expect(page.getByText('Source and target currencies must differ.')).toBeVisible();
 });
 
 test('shows API error message when conversion fails', async ({ page }) => {
@@ -79,10 +79,10 @@ test('shows API error message when conversion fails', async ({ page }) => {
   );
 
   await page.goto('/');
-  await expect(page.getByLabel('De', { exact: true })).toHaveValue('USD');
+  await expect(page.getByLabel('From', { exact: true })).toHaveValue('USD');
 
-  await page.getByLabel('Cantidad').fill('100');
-  await page.getByRole('button', { name: 'Convertir' }).click();
+  await page.getByLabel('Amount').fill('100');
+  await page.getByRole('button', { name: 'Convert' }).click();
 
   await expect(page.getByText('Only USD conversions supported')).toBeVisible();
 });

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -4,10 +4,10 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8787';
 
 async function handleResponse<T>(response: Response): Promise<T> {
   if (response.status === 404) {
-    throw new Error('Servicio no encontrado. Por favor, actualiza la página.');
+    throw new Error('Service not found. Please refresh the page.');
   }
   if (response.status >= 500) {
-    throw new Error('Algo salió mal. Por favor, inténtalo de nuevo más tarde.');
+    throw new Error('Something went wrong. Please try again later.');
   }
   if (!response.ok) {
     const data = (await response.json()) as { error: string };
@@ -21,7 +21,7 @@ export async function fetchCurrencies(): Promise<CurrenciesResponse> {
   try {
     response = await fetch(`${API_BASE}/currencies`);
   } catch {
-    throw new Error('No se pudo conectar. Por favor, inténtalo de nuevo.');
+    throw new Error('Could not connect. Please try again.');
   }
   return handleResponse<CurrenciesResponse>(response);
 }
@@ -36,7 +36,7 @@ export async function convertCurrency(
   try {
     response = await fetch(`${API_BASE}/convert?${params}`);
   } catch {
-    throw new Error('No se pudo conectar. Por favor, inténtalo de nuevo.');
+    throw new Error('Could not connect. Please try again.');
   }
   return handleResponse<ConversionResult>(response);
 }


### PR DESCRIPTION
## Summary

- Translated all Spanish UI labels back to English across the web package
- Updated `lang` attribute in `layout.tsx` from `es` to `en`
- Updated all corresponding unit tests and E2E test selectors

## Files changed

- `packages/web/src/components/CurrencyConverter.tsx` — all labels (Conversor, Cantidad, De, A, Convertir, etc.)
- `packages/web/src/app/layout.tsx` — page title, description, and `lang="en"`
- `packages/web/src/lib/api.ts` — English error messages
- `packages/web/src/components/CurrencyConverter.test.tsx` — updated label assertions
- `packages/web/src/e2e/converter.spec.ts` — updated selectors and test descriptions

## Test plan

- [x] 11/11 unit tests passing
- [x] E2E selectors updated to match new English labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)