### PR TITLE
feat: add swap icon between currency dropdowns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ packages/*/.wrangler/
 nul
 .next/
 *.tsbuildinfo
+test-results/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,4 +14,5 @@ Currency converter API that reads conversion rates from a CSV file. Built with T
 
 ## Development Process
 
-1. Before implementing, use DeepWiki's `ask_question` tool to get the latest information on relevant libraries so that code follows the most up-to-date APIs and patterns.
+1. **ALWAYS work in a feature branch** — never commit directly to `main`. Create a branch (e.g., `feature/...`, `fix/...`) before making any changes.
+2. Before implementing, use DeepWiki's `ask_question` tool to get the latest information on relevant libraries so that code follows the most up-to-date APIs and patterns.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
       "version": "0.0.0",
       "workspaces": [
         "packages/*"
-      ]
+      ],
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1"
+      }
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -999,7 +1002,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1475,7 +1477,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1498,7 +1499,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1521,7 +1521,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1538,7 +1537,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1555,7 +1553,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1572,7 +1569,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1589,7 +1585,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1606,7 +1601,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1623,7 +1617,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1640,7 +1633,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1657,7 +1649,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1674,7 +1665,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1691,7 +1681,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1714,7 +1703,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1737,7 +1725,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1760,7 +1747,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1783,7 +1769,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1806,7 +1791,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1829,7 +1813,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1852,7 +1835,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1875,7 +1857,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1895,7 +1876,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1915,7 +1895,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1935,7 +1914,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2799,7 +2777,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2971,8 +2948,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4677,7 +4653,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4688,7 +4663,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5393,8 +5367,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -6684,7 +6657,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7407,7 +7379,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7587,7 +7558,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7733,8 +7703,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,17 @@
   "name": "linkedin-currency-converter",
   "version": "0.0.0",
   "private": true,
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "dev:api": "npm run dev -w @repo/api",
     "dev:web": "npm run dev -w @repo/web",
     "test": "npm run test -w @repo/api",
     "test:unit": "npm run test:unit -w @repo/api",
     "test:integration": "npm run test:integration -w @repo/api"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1"
   }
 }

--- a/packages/web/src/components/CurrencyConverter.test.tsx
+++ b/packages/web/src/components/CurrencyConverter.test.tsx
@@ -202,4 +202,85 @@ describe('CurrencyConverter', () => {
     });
     expect(screen.getAllByRole('option', { name: 'EUR' })).toHaveLength(2);
   });
+
+  describe('Swap currencies button', () => {
+    it('renders a swap button', async () => {
+      render(<CurrencyConverter />);
+      await waitForCurrencies();
+
+      expect(screen.getByRole('button', { name: 'Swap currencies' })).toBeInTheDocument();
+    });
+
+    it('swaps From and To values when clicked', async () => {
+      const user = userEvent.setup();
+      render(<CurrencyConverter />);
+      await waitForCurrencies();
+
+      // Defaults: From=USD, To=EUR
+      expect(screen.getByLabelText('From')).toHaveValue('USD');
+      expect(screen.getByLabelText('To')).toHaveValue('EUR');
+
+      await user.click(screen.getByRole('button', { name: 'Swap currencies' }));
+
+      expect(screen.getByLabelText('From')).toHaveValue('EUR');
+      expect(screen.getByLabelText('To')).toHaveValue('USD');
+    });
+
+    it('clears conversion result when clicked', async () => {
+      const user = userEvent.setup();
+      mockConvertCurrency.mockResolvedValue(MOCK_RESULT);
+
+      render(<CurrencyConverter />);
+      await waitForCurrencies();
+
+      await user.type(screen.getByLabelText('Amount'), '100');
+      await user.click(screen.getByRole('button', { name: 'Convert' }));
+      await waitFor(() => expect(screen.getByText(/92\.50/)).toBeInTheDocument());
+
+      await user.click(screen.getByRole('button', { name: 'Swap currencies' }));
+
+      expect(screen.queryByText(/92\.50/)).not.toBeInTheDocument();
+    });
+
+    it('clears error when clicked', async () => {
+      const user = userEvent.setup();
+      mockConvertCurrency.mockRejectedValue(new Error('Conversion failed'));
+
+      render(<CurrencyConverter />);
+      await waitForCurrencies();
+
+      await user.type(screen.getByLabelText('Amount'), '100');
+      await user.click(screen.getByRole('button', { name: 'Convert' }));
+      await waitFor(() =>
+        expect(screen.getByText('Conversion failed')).toBeInTheDocument(),
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Swap currencies' }));
+
+      expect(screen.queryByText('Conversion failed')).not.toBeInTheDocument();
+    });
+
+    it('is disabled during loading', async () => {
+      const user = userEvent.setup();
+      let resolveFn!: (value: ConversionResult) => void;
+      mockConvertCurrency.mockImplementation(
+        () => new Promise((r) => { resolveFn = r; }),
+      );
+
+      render(<CurrencyConverter />);
+      await waitForCurrencies();
+
+      await user.type(screen.getByLabelText('Amount'), '100');
+      await user.click(screen.getByRole('button', { name: 'Convert' }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Swap currencies' })).toBeDisabled();
+      });
+
+      resolveFn(MOCK_RESULT);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Swap currencies' })).not.toBeDisabled();
+      });
+    });
+  });
 });

--- a/packages/web/src/components/CurrencyConverter.tsx
+++ b/packages/web/src/components/CurrencyConverter.tsx
@@ -39,6 +39,13 @@ export default function CurrencyConverter() {
     to !== '' &&
     from !== to;
 
+  const handleSwap = () => {
+    setFrom(to);
+    setTo(from);
+    setResult(null);
+    setError(null);
+  };
+
   const handleConvert = async () => {
     if (!isValid || loading) return;
     setLoading(true);
@@ -91,7 +98,7 @@ export default function CurrencyConverter() {
           />
         </div>
 
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-[1fr_auto_1fr] gap-x-2 items-end">
           <div>
             <label htmlFor="from" className="block text-sm font-medium text-gray-700 mb-1">
               From
@@ -111,6 +118,32 @@ export default function CurrencyConverter() {
               ))}
             </select>
           </div>
+
+          <button
+            type="button"
+            onClick={handleSwap}
+            disabled={loading || currencies.length === 0}
+            aria-label="Swap currencies"
+            className="mb-0.5 p-2 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              focusable="false"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M7 16l-4-4 4-4" />
+              <path d="M17 8l4 4-4 4" />
+              <line x1="3" y1="12" x2="21" y2="12" />
+            </svg>
+          </button>
 
           <div>
             <label htmlFor="to" className="block text-sm font-medium text-gray-700 mb-1">

--- a/packages/web/src/e2e/converter.spec.ts
+++ b/packages/web/src/e2e/converter.spec.ts
@@ -68,6 +68,27 @@ test('Convert button is disabled when From equals To', async ({ page }) => {
   await expect(page.getByText('Source and target currencies must differ.')).toBeVisible();
 });
 
+test('swap button swaps currencies and clears conversion result', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByLabel('From', { exact: true })).toHaveValue('USD');
+  await expect(page.getByLabel('To', { exact: true })).toHaveValue('EUR');
+
+  // Perform a conversion first
+  await page.getByLabel('Amount').fill('100');
+  await page.getByRole('button', { name: 'Convert' }).click();
+  await expect(page.getByText(/92\.50/)).toBeVisible();
+
+  // Click swap
+  await page.getByRole('button', { name: 'Swap currencies' }).click();
+
+  // Values should be swapped
+  await expect(page.getByLabel('From', { exact: true })).toHaveValue('EUR');
+  await expect(page.getByLabel('To', { exact: true })).toHaveValue('USD');
+
+  // Conversion result should be cleared
+  await expect(page.getByText(/92\.50/)).not.toBeVisible();
+});
+
 test('shows API error message when conversion fails', async ({ page }) => {
   // Override default convert mock with an error response
   await page.route(/\/convert/, (route) =>


### PR DESCRIPTION
## Summary

- Adds a swap button with an inline SVG icon between the From and To currency dropdowns
- Clicking the button swaps the selected currencies and clears any previous conversion result or error
- Button is disabled during loading or when currencies haven't loaded
- Includes `aria-label` and `aria-hidden`/`focusable` attributes for accessibility

## Test plan

- [x] 5 unit tests added (renders, swaps values, clears result, clears error, disabled during loading)
- [x] 1 E2E test added (convert, swap, verify values swapped and result cleared)
- [x] All 16 unit tests pass
- [x] All 5 E2E tests pass
- [ ] Visually verify swap icon placement and hover/disabled states in browser

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)