### PR TITLE
fix: prevent Infinity from bypassing amount validation

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -62,8 +62,8 @@ export default {
 			}
 
 			const amount = Number(amountStr);
-			if (isNaN(amount) || amount <= 0) {
-				return errorResponse('amount must be greater than zero', 400);
+			if (!isFinite(amount) || amount <= 0) {
+				return errorResponse('amount must be a finite number greater than zero', 400);
 			}
 
 			if (from === to) {

--- a/packages/api/test/integration/worker.test.ts
+++ b/packages/api/test/integration/worker.test.ts
@@ -43,6 +43,20 @@ describe('Worker fetch handler', () => {
 			expect(res.status).toBe(400);
 		});
 
+		it('returns 400 for Infinity amount', async () => {
+			const res = await SELF.fetch(`${BASE}/convert?amount=Infinity&from=USD&to=EUR`);
+			expect(res.status).toBe(400);
+			const body = await res.json<{ error: string }>();
+			expect(body.error).toContain('finite');
+		});
+
+		it('returns 400 for 1e309 (overflow to Infinity) amount', async () => {
+			const res = await SELF.fetch(`${BASE}/convert?amount=1e309&from=USD&to=EUR`);
+			expect(res.status).toBe(400);
+			const body = await res.json<{ error: string }>();
+			expect(body.error).toContain('finite');
+		});
+
 		it('returns 400 for same from/to', async () => {
 			const res = await SELF.fetch(`${BASE}/convert?amount=100&from=USD&to=USD`);
 			expect(res.status).toBe(400);


### PR DESCRIPTION
## Summary
- Replace `isNaN(amount)` with `!isFinite(amount)` to reject `Infinity` and `-Infinity` values
- `Number('1e309')` and `Number('Infinity')` now correctly return 400 instead of a broken 200 with `null` convertedAmount
- Added 2 integration tests for the Infinity edge cases

## Test plan
- [x] Existing 38 tests pass
- [x] 2 new tests added (`amount=Infinity`, `amount=1e309`)
- [ ] Manual: `curl '...?amount=1e309&from=USD&to=EUR'` returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)