### PR TITLE
feat: add IP-based rate limiting to API endpoints

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -41,14 +41,9 @@ export default {
 		const ip = request.headers.get('CF-Connecting-IP') ?? request.headers.get('X-Forwarded-For') ?? 'unknown';
 		const { allowed, retryAfterMs } = checkRateLimit(ip);
 		if (!allowed) {
-			return new Response(JSON.stringify({ error: 'Too many requests' }), {
-				status: 429,
-				headers: {
-					'Content-Type': 'application/json',
-					'Retry-After': String(Math.ceil(retryAfterMs / 1000)),
-					'Access-Control-Allow-Origin': '*',
-				},
-			});
+			const res = errorResponse('Too many requests', 429);
+			res.headers.set('Retry-After', String(Math.ceil(retryAfterMs / 1000)));
+			return res;
 		}
 
 		// All routes must be GET method

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,5 +1,6 @@
 import { fetchCurrencies, fetchRate } from './frankfurter';
 import { convert } from './converter';
+import { checkRateLimit } from './rate-limiter';
 import type { ErrorResponse } from './types';
 
 function jsonResponse(body: object, status = 200): Response {
@@ -32,6 +33,20 @@ export default {
 					'Access-Control-Allow-Origin': '*',
 					'Access-Control-Allow-Methods': 'GET, OPTIONS',
 					'Access-Control-Allow-Headers': 'Content-Type',
+				},
+			});
+		}
+
+		// Rate limiting
+		const ip = request.headers.get('CF-Connecting-IP') ?? request.headers.get('X-Forwarded-For') ?? 'unknown';
+		const { allowed, retryAfterMs } = checkRateLimit(ip);
+		if (!allowed) {
+			return new Response(JSON.stringify({ error: 'Too many requests' }), {
+				status: 429,
+				headers: {
+					'Content-Type': 'application/json',
+					'Retry-After': String(Math.ceil(retryAfterMs / 1000)),
+					'Access-Control-Allow-Origin': '*',
 				},
 			});
 		}

--- a/packages/api/src/rate-limiter.ts
+++ b/packages/api/src/rate-limiter.ts
@@ -1,0 +1,30 @@
+interface RateLimitEntry {
+	count: number;
+	resetTime: number;
+}
+
+const ipRequests = new Map<string, RateLimitEntry>();
+
+const WINDOW_MS = 60_000; // 1 minute
+const MAX_REQUESTS = 60;  // 60 requests per minute per IP
+
+export function checkRateLimit(ip: string): { allowed: boolean; retryAfterMs: number } {
+	const now = Date.now();
+	const entry = ipRequests.get(ip);
+
+	if (!entry || now >= entry.resetTime) {
+		ipRequests.set(ip, { count: 1, resetTime: now + WINDOW_MS });
+		return { allowed: true, retryAfterMs: 0 };
+	}
+
+	if (entry.count >= MAX_REQUESTS) {
+		return { allowed: false, retryAfterMs: entry.resetTime - now };
+	}
+
+	ipRequests.set(ip, { count: entry.count + 1, resetTime: entry.resetTime });
+	return { allowed: true, retryAfterMs: 0 };
+}
+
+export function resetRateLimiter(): void {
+	ipRequests.clear();
+}

--- a/packages/api/src/rate-limiter.ts
+++ b/packages/api/src/rate-limiter.ts
@@ -10,6 +10,7 @@ const MAX_REQUESTS = 60;  // 60 requests per minute per IP
 
 export function checkRateLimit(ip: string): { allowed: boolean; retryAfterMs: number } {
 	const now = Date.now();
+	evictExpired(now);
 	const entry = ipRequests.get(ip);
 
 	if (!entry || now >= entry.resetTime) {
@@ -23,6 +24,14 @@ export function checkRateLimit(ip: string): { allowed: boolean; retryAfterMs: nu
 
 	ipRequests.set(ip, { count: entry.count + 1, resetTime: entry.resetTime });
 	return { allowed: true, retryAfterMs: 0 };
+}
+
+function evictExpired(now: number): void {
+	for (const [key, entry] of ipRequests) {
+		if (now >= entry.resetTime) {
+			ipRequests.delete(key);
+		}
+	}
 }
 
 export function resetRateLimiter(): void {

--- a/packages/api/test/unit/rate-limiter.test.ts
+++ b/packages/api/test/unit/rate-limiter.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { checkRateLimit, resetRateLimiter } from '../../src/rate-limiter';
+
+describe('checkRateLimit', () => {
+	beforeEach(() => {
+		resetRateLimiter();
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('allows first request from an IP', () => {
+		const result = checkRateLimit('1.2.3.4');
+		expect(result.allowed).toBe(true);
+		expect(result.retryAfterMs).toBe(0);
+	});
+
+	it('allows up to MAX_REQUESTS (60) requests within the window', () => {
+		for (let i = 0; i < 60; i++) {
+			const result = checkRateLimit('1.2.3.4');
+			expect(result.allowed).toBe(true);
+		}
+	});
+
+	it('blocks the 61st request within the same window', () => {
+		for (let i = 0; i < 60; i++) {
+			checkRateLimit('1.2.3.4');
+		}
+		const result = checkRateLimit('1.2.3.4');
+		expect(result.allowed).toBe(false);
+		expect(result.retryAfterMs).toBeGreaterThan(0);
+	});
+
+	it('tracks different IPs independently', () => {
+		for (let i = 0; i < 60; i++) {
+			checkRateLimit('1.2.3.4');
+		}
+		// First IP is at limit
+		expect(checkRateLimit('1.2.3.4').allowed).toBe(false);
+		// Different IP should still be allowed
+		expect(checkRateLimit('5.6.7.8').allowed).toBe(true);
+	});
+
+	it('resets the counter after the window expires', () => {
+		for (let i = 0; i < 60; i++) {
+			checkRateLimit('1.2.3.4');
+		}
+		expect(checkRateLimit('1.2.3.4').allowed).toBe(false);
+
+		// Advance time past the 1-minute window
+		vi.advanceTimersByTime(60_001);
+
+		const result = checkRateLimit('1.2.3.4');
+		expect(result.allowed).toBe(true);
+		expect(result.retryAfterMs).toBe(0);
+	});
+
+	it('returns a positive retryAfterMs when blocked', () => {
+		for (let i = 0; i < 60; i++) {
+			checkRateLimit('1.2.3.4');
+		}
+		const result = checkRateLimit('1.2.3.4');
+		expect(result.allowed).toBe(false);
+		expect(result.retryAfterMs).toBeGreaterThan(0);
+		expect(result.retryAfterMs).toBeLessThanOrEqual(60_000);
+	});
+
+	it('increments count on each allowed request', () => {
+		// First 59 requests should be allowed
+		for (let i = 0; i < 59; i++) {
+			expect(checkRateLimit('10.0.0.1').allowed).toBe(true);
+		}
+		// 60th request is still within limit
+		expect(checkRateLimit('10.0.0.1').allowed).toBe(true);
+		// 61st request exceeds limit
+		expect(checkRateLimit('10.0.0.1').allowed).toBe(false);
+	});
+});
+
+describe('resetRateLimiter', () => {
+	it('clears all tracked IPs', () => {
+		for (let i = 0; i < 60; i++) {
+			checkRateLimit('1.2.3.4');
+		}
+		expect(checkRateLimit('1.2.3.4').allowed).toBe(false);
+
+		resetRateLimiter();
+
+		expect(checkRateLimit('1.2.3.4').allowed).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- Add in-memory IP-based rate limiter (60 req/min per IP)
- Reads `CF-Connecting-IP` header (Cloudflare) with `X-Forwarded-For` fallback
- Returns 429 with `Retry-After` header when limit exceeded
- Protects upstream Frankfurter API from abuse

## Test plan
- [x] Existing 38 tests pass
- [x] 8 new unit tests for rate limiter (window expiry, per-IP tracking, reset)
- [ ] Manual: rapid-fire requests return 429 after 60th

🤖 Generated with [Claude Code](https://claude.com/claude-code)