### PR TITLE
fix: add runtime validation of Frankfurter API responses

### DIFF
--- a/packages/api/src/frankfurter.ts
+++ b/packages/api/src/frankfurter.ts
@@ -19,7 +19,11 @@ export async function fetchCurrencies(): Promise<Record<string, string>> {
 	const response = await fetch(`${FRANKFURTER_BASE}/currencies`);
 	if (!response.ok) throw new Error(`Frankfurter /currencies failed: ${response.status}`);
 
-	const data = (await response.json()) as Record<string, string>;
+	const raw: unknown = await response.json();
+	if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+		throw new Error('Frankfurter /currencies returned unexpected response shape');
+	}
+	const data = raw as Record<string, string>;
 	currenciesCache = { date: today, currencies: data };
 	return data;
 }
@@ -34,10 +38,22 @@ export async function fetchRate(from: string, to: string): Promise<{ rate: numbe
 	const response = await fetch(`${FRANKFURTER_BASE}/latest?base=${from}&symbols=${to}`);
 	if (!response.ok) throw new Error(`Frankfurter /latest failed: ${response.status}`);
 
-	const data = (await response.json()) as { base: string; date: string; rates: Record<string, number> };
+	const raw: unknown = await response.json();
+	if (
+		typeof raw !== 'object' || raw === null ||
+		!('rates' in raw) || typeof (raw as Record<string, unknown>).rates !== 'object' ||
+		!('date' in raw) || typeof (raw as Record<string, unknown>).date !== 'string'
+	) {
+		throw new Error('Frankfurter /latest returned unexpected response shape');
+	}
+	const data = raw as { base: string; date: string; rates: Record<string, number> };
+	const rate = data.rates[to];
+	if (typeof rate !== 'number' || !isFinite(rate) || rate <= 0) {
+		throw new Error(`Frankfurter returned invalid rate for ${to}`);
+	}
 	const existing = rateCache.get(from);
 	if (existing && existing.date === data.date) {
-		existing.rates[to] = data.rates[to];
+		rateCache.set(from, { ...existing, rates: { ...existing.rates, [to]: data.rates[to] } });
 	} else {
 		rateCache.set(from, { date: data.date, rates: { ...data.rates } });
 	}

--- a/packages/api/test/unit/frankfurter.test.ts
+++ b/packages/api/test/unit/frankfurter.test.ts
@@ -60,6 +60,44 @@ describe('fetchCurrencies', () => {
 
 		await expect(fetchCurrencies()).rejects.toThrow('Frankfurter /currencies failed: 503');
 	});
+
+	it('throws when response is an array', async () => {
+		vi.stubGlobal('fetch', makeFetchMock([] as unknown as object));
+
+		await expect(fetchCurrencies()).rejects.toThrow(
+			'Frankfurter /currencies returned unexpected response shape',
+		);
+	});
+
+	it('throws when response is a string', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				status: 200,
+				json: () => Promise.resolve('not-an-object'),
+			}),
+		);
+
+		await expect(fetchCurrencies()).rejects.toThrow(
+			'Frankfurter /currencies returned unexpected response shape',
+		);
+	});
+
+	it('throws when response is null', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				status: 200,
+				json: () => Promise.resolve(null),
+			}),
+		);
+
+		await expect(fetchCurrencies()).rejects.toThrow(
+			'Frankfurter /currencies returned unexpected response shape',
+		);
+	});
 });
 
 describe('fetchRate', () => {
@@ -127,5 +165,108 @@ describe('fetchRate', () => {
 		vi.stubGlobal('fetch', makeFetchMock({}, 503));
 
 		await expect(fetchRate('USD', 'EUR')).rejects.toThrow('Frankfurter /latest failed: 503');
+	});
+
+	it('throws when response is missing the rates field', async () => {
+		vi.stubGlobal('fetch', makeFetchMock({ base: 'USD', date: TODAY }));
+
+		await expect(fetchRate('USD', 'EUR')).rejects.toThrow(
+			'Frankfurter /latest returned unexpected response shape',
+		);
+	});
+
+	it('throws when response is missing the date field', async () => {
+		vi.stubGlobal('fetch', makeFetchMock({ base: 'USD', rates: { EUR: 0.89 } }));
+
+		await expect(fetchRate('USD', 'EUR')).rejects.toThrow(
+			'Frankfurter /latest returned unexpected response shape',
+		);
+	});
+
+	it('throws when response date is not a string', async () => {
+		vi.stubGlobal('fetch', makeFetchMock({ base: 'USD', date: 20241201, rates: { EUR: 0.89 } }));
+
+		await expect(fetchRate('USD', 'EUR')).rejects.toThrow(
+			'Frankfurter /latest returned unexpected response shape',
+		);
+	});
+
+	it('throws when response is an array', async () => {
+		vi.stubGlobal('fetch', makeFetchMock([] as unknown as object));
+
+		await expect(fetchRate('USD', 'EUR')).rejects.toThrow(
+			'Frankfurter /latest returned unexpected response shape',
+		);
+	});
+
+	it('throws when response is null', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				status: 200,
+				json: () => Promise.resolve(null),
+			}),
+		);
+
+		await expect(fetchRate('USD', 'EUR')).rejects.toThrow(
+			'Frankfurter /latest returned unexpected response shape',
+		);
+	});
+
+	it('throws when the rate for the requested symbol is not a number', async () => {
+		vi.stubGlobal(
+			'fetch',
+			makeFetchMock({ base: 'USD', date: TODAY, rates: { EUR: 'not-a-number' } }),
+		);
+
+		await expect(fetchRate('USD', 'EUR')).rejects.toThrow(
+			'Frankfurter returned invalid rate for EUR',
+		);
+	});
+
+	it('throws when the rate is zero', async () => {
+		vi.stubGlobal('fetch', makeFetchMock({ base: 'USD', date: TODAY, rates: { EUR: 0 } }));
+
+		await expect(fetchRate('USD', 'EUR')).rejects.toThrow(
+			'Frankfurter returned invalid rate for EUR',
+		);
+	});
+
+	it('throws when the rate is negative', async () => {
+		vi.stubGlobal('fetch', makeFetchMock({ base: 'USD', date: TODAY, rates: { EUR: -1.5 } }));
+
+		await expect(fetchRate('USD', 'EUR')).rejects.toThrow(
+			'Frankfurter returned invalid rate for EUR',
+		);
+	});
+
+	it('throws when the rate is Infinity', async () => {
+		vi.stubGlobal('fetch', makeFetchMock({ base: 'USD', date: TODAY, rates: { EUR: Infinity } }));
+
+		await expect(fetchRate('USD', 'EUR')).rejects.toThrow(
+			'Frankfurter returned invalid rate for EUR',
+		);
+	});
+
+	it('merges new symbol into existing cache entry immutably when date matches', async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValueOnce({
+				ok: true,
+				json: () => Promise.resolve({ base: 'USD', date: TODAY, rates: { EUR: 0.89 } }),
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				json: () => Promise.resolve({ base: 'USD', date: TODAY, rates: { GBP: 0.79 } }),
+			});
+		vi.stubGlobal('fetch', mockFetch);
+
+		const first = await fetchRate('USD', 'EUR');
+		const second = await fetchRate('USD', 'GBP');
+
+		expect(first.rate).toBe(0.89);
+		expect(second.rate).toBe(0.79);
+		expect(mockFetch).toHaveBeenCalledTimes(2);
 	});
 });


### PR DESCRIPTION
## Summary
- Validate Frankfurter API response shape at runtime instead of relying on unsafe `as` casts
- Reject malformed responses (missing rates, non-string date, invalid rate values)
- Fix mutable cache mutation — use immutable spread pattern instead of direct property assignment
- Prevents cache poisoning from undefined rates or compromised upstream

## Test plan
- [x] Existing 38 tests pass
- [x] 13 new unit tests for malformed response handling (null, array, missing fields, invalid rates)
- [ ] Manual: verify normal conversion still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)