### PR TITLE
fix: add security headers to API and web responses

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -10,6 +10,9 @@ function jsonResponse(body: object, status = 200): Response {
 			'Access-Control-Allow-Origin': '*',
 			'Access-Control-Allow-Methods': 'GET, OPTIONS',
 			'Access-Control-Allow-Headers': 'Content-Type',
+			'X-Content-Type-Options': 'nosniff',
+			'Cache-Control': 'no-store',
+			'Referrer-Policy': 'no-referrer',
 		},
 	});
 }
@@ -32,6 +35,9 @@ export default {
 					'Access-Control-Allow-Origin': '*',
 					'Access-Control-Allow-Methods': 'GET, OPTIONS',
 					'Access-Control-Allow-Headers': 'Content-Type',
+					'X-Content-Type-Options': 'nosniff',
+					'Cache-Control': 'no-store',
+					'Referrer-Policy': 'no-referrer',
 				},
 			});
 		}

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,4 +1,18 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  poweredByHeader: false,
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+        ],
+      },
+    ];
+  },
+};
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- Add `X-Content-Type-Options: nosniff`, `Cache-Control: no-store`, `Referrer-Policy: no-referrer` to all API responses (including OPTIONS preflight)
- Configure Next.js with `poweredByHeader: false` and security headers (`X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy`)

## Test plan
- [x] Existing 38 API tests pass
- [ ] Manual: verify response headers include new security headers
- [ ] Manual: verify `X-Powered-By` header is absent from web responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)